### PR TITLE
Expose a context manager for histograms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ an internal registry, so you can access it in different places in your applicati
 
 The ``metrics`` registry is thread-safe, you can safely use it in multi-threaded web servers.
 
-Now let's decorate some function::
+Using the ``with_histogram`` decorator we can time a function::
 
     >>> import time, random
     >>> @metrics.with_histogram("test")
@@ -69,6 +69,14 @@ and let's see the results::
 
     >>> metrics.get("test")
     {'arithmetic_mean': 0.41326093673706055, 'kind': 'histogram', 'skewness': 0.2739718270714368, 'harmonic_mean': 0.14326954591313346, 'min': 0.0613858699798584, 'standard_deviation': 0.4319169569113129, 'median': 0.2831099033355713, 'histogram': [(1.0613858699798584, 3), (2.0613858699798584, 0)], 'percentile': [(50, 0.2831099033355713), (75, 0.2831099033355713), (90, 0.895287036895752), (95, 0.895287036895752), (99, 0.895287036895752), (99.9, 0.895287036895752)], 'n': 3, 'max': 0.895287036895752, 'variance': 0.18655225766752892, 'geometric_mean': 0.24964828731906127, 'kurtosis': -2.3333333333333335}
+
+It is also possible to time specific sections of the code by using the ``time`` context manager::
+
+    >>> import time, random
+    ... def my_worker():
+    ...     with metrics.metric("test").time():
+    ...         time.sleep(random.random())
+    ...
 
 Let's print the metrics data on the screen every 5 seconds::
 

--- a/appmetrics/histogram.py
+++ b/appmetrics/histogram.py
@@ -33,15 +33,16 @@ DEFAULT_EXPONENTIAL_DECAY_FACTOR = 0.015
 
 def search_greater(values, target):
     """
-    Return the first index for which target is greater or equal to the first item of the tuple found in values
+    Return the first index for which target is greater or equal to the first
+    item of the tuple found in values
     """
     first = 0
     last = len(values)
 
     while first < last:
-        middle = (first+last)//2
+        middle = (first + last) // 2
         if values[middle][0] < target:
-            first = middle+1
+            first = middle + 1
         else:
             last = middle
 
@@ -52,13 +53,15 @@ class ReservoirBase(object):
     __metaclass__ = abc.ABCMeta
 
     """
-    Base class for reservoirs. Subclass and override _do_add, _get_values and _same_parameters
+    Base class for reservoirs. Subclass and override _do_add, _get_values and
+    _same_parameters
     """
 
     def add(self, value):
         """
         Add a value to the reservoir
-        The value will be casted to a floating-point, so a TypeError or a ValueError may be raised.
+        The value will be casted to a floating-point, so a TypeError or a
+        ValueError may be raised.
         """
 
         if not isinstance(value, float):
@@ -74,7 +77,6 @@ class ReservoirBase(object):
 
         return self._get_values()
 
-
     @property
     def sorted_values(self):
         """
@@ -85,7 +87,8 @@ class ReservoirBase(object):
 
     def same_kind(self, other):
         """
-        Return True if "other" is an object of the same type and it was instantiated with the same parameters
+        Return True if "other" is an object of the same type and it was
+        instantiated with the same parameters
         """
 
         return type(self) is type(other) and self._same_parameters(other)
@@ -105,15 +108,17 @@ class ReservoirBase(object):
     @abc.abstractmethod
     def _same_parameters(self, other):
         """
-        Return True if this object has been instantiated with the same parameters as "other".
+        Return True if this object has been instantiated with the same
+        parameters as "other".
         Override in subclasses
         """
 
 
 class UniformReservoir(ReservoirBase):
     """
-    A random sampling reservoir of floating-point values. Uses Vitter's Algorithm R to produce a statistically
-    representative sample (http://www.cs.umd.edu/~samir/498/vitter.pdf)
+    A random sampling reservoir of floating-point values. Uses Vitter's
+    Algorithm R to produce a statistically representative sample
+    (http://www.cs.umd.edu/~samir/498/vitter.pdf)
     """
 
     def __init__(self, size=DEFAULT_UNIFORM_RESERVOIR_SIZE):
@@ -130,8 +135,8 @@ class UniformReservoir(ReservoirBase):
                 self._values[self.count] = value
                 changed = True
             else:
-                # not randint() because it yields different values on python 3, it
-                # would be a nightmare to test.
+                # not randint() because it yields different values on
+                # python 3, it would be a nightmare to test.
                 k = int(random.uniform(0, self.count))
                 if k < self.size:
                     self._values[k] = value
@@ -201,7 +206,8 @@ class SlidingTimeWindowReservoir(ReservoirBase):
     def tick(self, now):
         target = now - self.window_size
 
-        # the values are sorted by the first element (timestamp), so let's perform a dichotomic search
+        # the values are sorted by the first element (timestamp), so let's
+        # perform a dichotomic search
         idx = search_greater(self._values, target)
 
         # older values found, discard them
@@ -230,14 +236,16 @@ class ExponentialDecayingReservoir(ReservoirBase):
     See http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf
     """
 
-    #TODO: replace the sort()s with a proper data structure (btree/skiplist). However, since the list
-    # is keep sorted (and it should be very small), the sort() shouldn't dramatically slow down
-    # the insertions, also considering that the search can be log(n) in that way
+    # TODO: replace the sort()s with a proper data structure (btree/skiplist).
+    # However, since the list is keep sorted (and it should be very small),
+    # the sort() shouldn't dramatically slow down the insertions, also
+    # considering that the search can be log(n) in that way
 
     RESCALE_THRESHOLD = 3600
     EPSILON = 1e-12
 
-    def __init__(self, size=DEFAULT_UNIFORM_RESERVOIR_SIZE, alpha=DEFAULT_EXPONENTIAL_DECAY_FACTOR):
+    def __init__(self, size=DEFAULT_UNIFORM_RESERVOIR_SIZE,
+                 alpha=DEFAULT_EXPONENTIAL_DECAY_FACTOR):
         self.size = size
         self.alpha = alpha
         self.start_time = time.time()
@@ -250,13 +258,15 @@ class ExponentialDecayingReservoir(ReservoirBase):
 
     def _lookup(self, timestamp):
         """
-        Return the index of the value associated with "timestamp" if any, else None.
-        Since the timestamps are floating-point values, they are considered equal if their absolute
-        difference is smaller than self.EPSILON
+        Return the index of the value associated with "timestamp" if any, else
+        None. Since the timestamps are floating-point values, they are
+        considered equal if their absolute difference is smaller than
+        self.EPSILON
         """
 
         idx = search_greater(self._values, timestamp)
-        if idx < len(self._values) and math.fabs(self._values[idx][0] - timestamp) < self.EPSILON:
+        if (idx < len(self._values)
+                and math.fabs(self._values[idx][0] - timestamp) < self.EPSILON):
             return idx
         return None
 
@@ -275,7 +285,7 @@ class ExponentialDecayingReservoir(ReservoirBase):
         self.rescale(now)
 
         rnd = random.random()
-        weighted_time = self.weight(now-self.start_time) / rnd
+        weighted_time = self.weight(now - self.start_time) / rnd
 
         changed = False
 
@@ -306,13 +316,12 @@ class ExponentialDecayingReservoir(ReservoirBase):
                 original_values = self._values[:]
                 self._values = []
                 for i, (k, v) in enumerate(original_values):
-                    k *= math.exp(-self.alpha * (now-self.start_time))
+                    k *= math.exp(-self.alpha * (now - self.start_time))
                     self._put(k, v)
 
                 self.count = len(self._values)
                 self.start_time = now
                 self.next_scale_time = self.start_time + self.RESCALE_THRESHOLD
-
 
     def _get_values(self):
         return [y for x, y in self._values[:max(self.count, self.size)]]
@@ -325,7 +334,8 @@ class ExponentialDecayingReservoir(ReservoirBase):
 
 
 class Histogram(object):
-    """A metric which calculates some statistics over the distribution of some values"""
+    """A metric which calculates some statistics over the distribution of some
+    values"""
 
     def __init__(self, reservoir):
         self.reservoir = reservoir
@@ -345,7 +355,7 @@ class Histogram(object):
         t1 = time.time()
         yield
         t2 = time.time()
-        self.notify(t2-t1)
+        self.notify(t2 - t1)
 
     def get(self):
         """Return the computed statistics over the gathered data"""

--- a/appmetrics/histogram.py
+++ b/appmetrics/histogram.py
@@ -352,6 +352,7 @@ class Histogram(object):
 
     @contextmanager
     def time(self):
+        """A context manager which times execution of a piece of code"""
         t1 = time.time()
         yield
         t2 = time.time()

--- a/appmetrics/histogram.py
+++ b/appmetrics/histogram.py
@@ -21,6 +21,7 @@ import abc
 import time
 import operator
 import math
+from contextlib import contextmanager
 
 from . import statistics, exceptions, py3comp
 
@@ -338,6 +339,13 @@ class Histogram(object):
         """Return the raw underlying data"""
 
         return self.reservoir.values
+
+    @contextmanager
+    def time(self):
+        t1 = time.time()
+        yield
+        t2 = time.time()
+        self.notify(t2-t1)
 
     def get(self):
         """Return the computed statistics over the gathered data"""

--- a/appmetrics/tests/test_histogram.py
+++ b/appmetrics/tests/test_histogram.py
@@ -361,6 +361,13 @@ class TestHistogram(object):
             [mock.call(1.2)])
         nt.assert_equal(result, self.reservoir.add.return_value)
 
+    def test_time(self):
+        self.histogram.notify = mock.Mock()
+        with self.histogram.time():
+            pass
+
+        nt.assert_equal(self.histogram.notify.call_count, 1)
+
     def test_raw_data(self):
         result = self.histogram.raw_data()
         nt.assert_equal(result, self.reservoir.values)


### PR DESCRIPTION
- Makes it a lot easier to use AppMetrics to time specific parts of the code
- Modifies the documentation a little, to make it clear that `with_histogram` will in fact "time" your code when used in a decorator.