### PR TITLE
Free project from unnecessary dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ python:
 
 # command to install dependencies
 install:
-  - "pip install ."
-  - "pip install -r requirements.txt"
+  - pip install -e ".[test,dev,werkzeug]"
 
 # command to run tests
 script:

--- a/appmetrics/py3comp.py
+++ b/appmetrics/py3comp.py
@@ -20,6 +20,13 @@ Python 3 compatibility
 
 import sys
 import json
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
 
 PY3 = sys.version_info[0] == 3
 

--- a/appmetrics/tests/test_histogram.py
+++ b/appmetrics/tests/test_histogram.py
@@ -1,10 +1,9 @@
 import random
 
 from nose import tools as nt
-import mock
 
 from .. import histogram as mm
-from ..py3comp import assert_items_equal
+from ..py3comp import assert_items_equal, mock
 
 def test_uniform_reservoir_defaults():
     ur = mm.UniformReservoir()

--- a/appmetrics/tests/test_meter.py
+++ b/appmetrics/tests/test_meter.py
@@ -1,9 +1,9 @@
 import logging
 
 from nose.tools import assert_equal, assert_almost_equal, raises
-import mock
 
 from .. import meter as mm
+from ..py3comp import mock
 
 
 log = logging.getLogger(__name__)

--- a/appmetrics/tests/test_metrics.py
+++ b/appmetrics/tests/test_metrics.py
@@ -1,7 +1,7 @@
-import mock
 from nose.tools import assert_equal, assert_in, raises, assert_is, assert_is_instance, assert_false, assert_true
 
 from .. import metrics as mm, exceptions, histogram, simple_metrics as simple, meter
+from ..py3comp import mock
 
 
 class TestMetricsModule(object):

--- a/appmetrics/tests/test_reporter.py
+++ b/appmetrics/tests/test_reporter.py
@@ -5,9 +5,9 @@ import tempfile
 import shutil
 
 from nose import tools as nt
-import mock
 
 from .. import reporter as mm, metrics, py3comp
+from ..py3comp import mock
 
 
 class TestReporter(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-coverage==3.7.1
-ipython==1.1.0
-mock==1.0.1
-nose==1.3.0
-python-coveralls==2.4.2
-werkzeug

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 from setuptools import setup, find_packages
 
+try:
+    from unittest import mock
+except ImportError:
+    has_mock = False
+else:
+    has_mock = True
+
 setup(
     name="AppMetrics",
     version="0.4.2",
@@ -9,6 +16,11 @@ setup(
     scripts=[],
 
     install_requires=[],
+    extras_require={
+        'test': ['nose==1.3.0'] + ['mock==1.0.1'] if has_mock else [],
+        'dev': ['coverage==3.7.1', 'ipython==1.1.0', 'python-coveralls==2.4.2'],
+        'werkzeug': ['werkzeug']
+    },
 
     package_data={},
 

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,27 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = "AppMetrics",
-    version = "0.4.2",
+    name="AppMetrics",
+    version="0.4.2",
 
-    packages = find_packages(),
+    packages=find_packages(),
 
-    scripts = [],
+    scripts=[],
 
-    install_requires = [],
+    install_requires=[],
 
-    package_data = {
-    },
+    package_data={},
 
     # metadata for upload to PyPI
-    author = "Antonio Valente",
-    author_email = "y3sman@gmail.com",
-    description = "Application metrics collector",
-    license = "Apache 2.0",
-    keywords = ["metrics", "folsom", "histogram", "metric", "monitor"],
-    url = "https://github.com/avalente/appmetrics",
-    platforms = 'Platform Independent',
+    author="Antonio Valente",
+    author_email="y3sman@gmail.com",
+    description="Application metrics collector",
+    license="Apache 2.0",
+    keywords=["metrics", "folsom", "histogram", "metric", "monitor"],
+    url="https://github.com/avalente/appmetrics",
+    platforms='Platform Independent',
 
-    classifiers = [
+    classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
appmetrics works perfectly without need to depend on ipython, werkzeug and the other libs. Also, since Python 3.3 mock is available in stdlib what makes dependency on external mock package redundant.
